### PR TITLE
Conjugate yerine direkt __call__ kısayolu

### DIFF
--- a/conj/__init__.py
+++ b/conj/__init__.py
@@ -86,3 +86,7 @@ class Conj(object):
                     word = '%s%s' % (word[:-1], self.SOFTENINGS[conjType][ll])
                 return '%s%s%s%s' % (word, infix, suffix, lastLetter)
         return word
+        
+    __call__ = conjugate
+
+conj = Conj()


### PR DESCRIPTION
Bu sayede API şöyle olacak

    >>> conj = Conj()
    >>> conj(word, properName=False, conjType='dative')

Hatta direkt Conj instantiate etmek yerine bir tane zaten instantiate edilmiş bir obje bırakabilirsin kütüphanenin içinde. Onu da ekledim sonuna.