### PR TITLE
Added tests and support for accent marks

### DIFF
--- a/conj/__init__.py
+++ b/conj/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 VOWEL_LETTERS = [
-    'a', 'e', 'ı', 'i', 'o', 'ö', 'u', 'ü'
+    'a', 'e', 'ı', 'i', 'o', 'ö', 'u', 'ü', 'û', 'â',
 ]
 VOWELS = {}
 VOWELS['dative'] = \
@@ -102,7 +102,19 @@ class Conj(object):
 
     def getSuffix(self, word, conjType):
         lv = self.getLastVowel(word)
+
         if lv:
+            ll = self.getLastLetter(word)
+
+            if ll == 'l' and lv == 'â':
+                lv = 'e'
+            elif ll == 'l' and lv == 'û':
+                lv = 'ü'
+            elif lv == 'â':
+                lv = 'a'
+            elif lv ==   'û':
+                lv = 'u'
+
             return VOWELS[conjType][lv]
 
     def makeProperName(self, word):

--- a/conj/__init__.py
+++ b/conj/__init__.py
@@ -112,7 +112,7 @@ class Conj(object):
                 lv = 'ü'
             elif lv == 'â':
                 lv = 'a'
-            elif lv ==   'û':
+            elif lv == 'û':
                 lv = 'u'
 
             return VOWELS[conjType][lv]

--- a/conj/__init__.py
+++ b/conj/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 VOWEL_LETTERS = [
-    'a', 'e', 'ı', 'i', 'o', 'ö', 'u', 'ü', 'û', 'â',
+    'a', 'e', 'ı', 'i', 'o', 'ö', 'u', 'ü', 'û', 'â'
 ]
 VOWELS = {}
 VOWELS['dative'] = \

--- a/tests.py
+++ b/tests.py
@@ -23,7 +23,8 @@ class ConjugationTest(TestCase):
             ['o',       'ona',        False],
             ['Ben',     'Ben\'e',     True],
             ['Sen',     'Sen\'e',     True],
-            ['O',       'O\'ya',      True]
+            ['O',       'O\'ya',      True],
+            ['usûl',    'usûle',      False],
         ]
 
         for case in cases:
@@ -48,7 +49,8 @@ class ConjugationTest(TestCase):
             ['Ben',     'Ben\'i',     True],
             ['Sen',     'Sen\'i',     True],
             ['O',       'O\'yu',      True],
-            ['ptn',     'ptn',        False]
+            ['ptn',     'ptn',        False],
+            ['usûl',    'usûlü',      False],
         ]
 
         for case in cases:
@@ -78,7 +80,8 @@ class ConjugationTest(TestCase):
             ['kulaç',   'kulaçta',     False],
             ['savaş',   'savaşta',     False],
             ['seyyah',  'seyyahta',    False],
-            ['top',     'topta',       False]
+            ['top',     'topta',       False],
+            ['usûl',    'usûlde',      False],
         ]
 
         for case in cases:
@@ -108,7 +111,8 @@ class ConjugationTest(TestCase):
             ['kulaç',   'kulaçtan',     False],
             ['savaş',   'savaştan',     False],
             ['seyyah',  'seyyahtan',    False],
-            ['top',     'toptan',       False]
+            ['top',     'toptan',       False],
+            ['usûl',    'usûlden',      False],
         ]
 
         for case in cases:
@@ -120,7 +124,8 @@ class ConjugationTest(TestCase):
             ['ürgüp',   'Ürgüplü',      True],
             ['bolu',    'Bolulu',       True],
             ['izmir',   'İzmirli',      True],
-            ['ığdır',   'Iğdırlı',      True]
+            ['ığdır',   'Iğdırlı',      True],
+            ['usûl',    'usûllü',       False],
         ]
 
         for case in cases:
@@ -131,7 +136,8 @@ class ConjugationTest(TestCase):
             ['piton',   'pitonsuz',     False],
             ['keten',   'ketensiz',     False],
             ['adana',   'Adana\'sız',   True],
-            ['ürgüp',   'ürgüpsüz',     False]
+            ['ürgüp',   'ürgüpsüz',     False],
+            ['usûl',    'usûlsüz',      False],
         ]
 
         for case in cases:
@@ -156,7 +162,8 @@ class ConjugationTest(TestCase):
             ['ben',     'Ben\'in',      True],
             ['sen',     'Sen\'in',      True],
             ['o',       'O\'nun',       True],
-            ['biz',     'Biz\'in',      True]
+            ['biz',     'Biz\'in',      True],
+            ['usûl',    'usûlün',       False],
         ]
 
         for case in cases:
@@ -170,7 +177,8 @@ class ConjugationTest(TestCase):
             ['biz',     'bizler',       False],
             ['siz',     'sizler',       False],
             ['o',       'onlar',        False],
-            ['o',       'O\'lar',       True]
+            ['o',       'O\'lar',       True],
+            ['usûl',    'usûller',      False],
         ]
 
         for case in cases:

--- a/tests.py
+++ b/tests.py
@@ -51,6 +51,7 @@ class ConjugationTest(TestCase):
             ['O',       'O\'yu',      True],
             ['ptn',     'ptn',        False],
             ['usûl',    'usûlü',      False],
+            ['mahlûk',  'mahlûğu',    False],
         ]
 
         for case in cases:
@@ -82,6 +83,7 @@ class ConjugationTest(TestCase):
             ['seyyah',  'seyyahta',    False],
             ['top',     'topta',       False],
             ['usûl',    'usûlde',      False],
+            ['istikbâl','istikbâlde',  False],
         ]
 
         for case in cases:
@@ -138,6 +140,7 @@ class ConjugationTest(TestCase):
             ['adana',   'Adana\'sız',   True],
             ['ürgüp',   'ürgüpsüz',     False],
             ['usûl',    'usûlsüz',      False],
+            ['ahlâk',   'ahlâksız',     False],
         ]
 
         for case in cases:

--- a/tests.py
+++ b/tests.py
@@ -24,7 +24,7 @@ class ConjugationTest(TestCase):
             ['Ben',     'Ben\'e',     True],
             ['Sen',     'Sen\'e',     True],
             ['O',       'O\'ya',      True],
-            ['usûl',    'usûle',      False],
+            ['usûl',    'usûle',      False]
         ]
 
         for case in cases:
@@ -51,7 +51,7 @@ class ConjugationTest(TestCase):
             ['O',       'O\'yu',      True],
             ['ptn',     'ptn',        False],
             ['usûl',    'usûlü',      False],
-            ['mahlûk',  'mahlûğu',    False],
+            ['mahlûk',  'mahlûğu',    False]
         ]
 
         for case in cases:
@@ -83,7 +83,7 @@ class ConjugationTest(TestCase):
             ['seyyah',  'seyyahta',    False],
             ['top',     'topta',       False],
             ['usûl',    'usûlde',      False],
-            ['istikbâl','istikbâlde',  False],
+            ['istikbâl','istikbâlde',  False]
         ]
 
         for case in cases:
@@ -114,7 +114,7 @@ class ConjugationTest(TestCase):
             ['savaş',   'savaştan',     False],
             ['seyyah',  'seyyahtan',    False],
             ['top',     'toptan',       False],
-            ['usûl',    'usûlden',      False],
+            ['usûl',    'usûlden',      False]
         ]
 
         for case in cases:
@@ -127,7 +127,7 @@ class ConjugationTest(TestCase):
             ['bolu',    'Bolulu',       True],
             ['izmir',   'İzmirli',      True],
             ['ığdır',   'Iğdırlı',      True],
-            ['usûl',    'usûllü',       False],
+            ['usûl',    'usûllü',       False]
         ]
 
         for case in cases:
@@ -140,7 +140,7 @@ class ConjugationTest(TestCase):
             ['adana',   'Adana\'sız',   True],
             ['ürgüp',   'ürgüpsüz',     False],
             ['usûl',    'usûlsüz',      False],
-            ['ahlâk',   'ahlâksız',     False],
+            ['ahlâk',   'ahlâksız',     False]
         ]
 
         for case in cases:
@@ -166,7 +166,7 @@ class ConjugationTest(TestCase):
             ['sen',     'Sen\'in',      True],
             ['o',       'O\'nun',       True],
             ['biz',     'Biz\'in',      True],
-            ['usûl',    'usûlün',       False],
+            ['usûl',    'usûlün',       False]
         ]
 
         for case in cases:
@@ -181,7 +181,7 @@ class ConjugationTest(TestCase):
             ['siz',     'sizler',       False],
             ['o',       'onlar',        False],
             ['o',       'O\'lar',       True],
-            ['usûl',    'usûller',      False],
+            ['usûl',    'usûller',      False]
         ]
 
         for case in cases:


### PR DESCRIPTION
In Turkish language if a words ends with letter "l" and the vowel before last letter has accent (only "u" and "a" can have accent mark) the suffix should be changed to "ü" and "e" respetively. 

Implemented and added tests. 
